### PR TITLE
Fix render.yaml: "env" --> "runtime"

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -1,7 +1,7 @@
 services:
   - type: web
     name: bun
-    env: docker
+    runtime: docker
     repo: https://github.com/render-examples/bun-docker
     plan: starter
     autoDeploy: false


### PR DESCRIPTION
Per the [render.yaml schema](https://docs.render.com/blueprint-spec#runtime), `env` is still supported but is superseded by `runtime`. Using `env` will show a schema error if using the `render.yaml` validator in an IDE like VS Code.